### PR TITLE
Pharmacy low stock alerts cucumber tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,11 @@ GEM
     erubis (2.7.0)
     execjs (1.4.0)
       multi_json (~> 1.0)
+    factory_girl (4.1.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.1.0)
+      factory_girl (~> 4.1.0)
+      railties (>= 3.0.0)
     ffi (1.1.5)
     gherkin (2.11.4)
       json (>= 1.4.6)
@@ -161,6 +166,7 @@ DEPENDENCIES
   coffee-rails (~> 3.2.1)
   cucumber-rails
   database_cleaner
+  factory_girl_rails
   haml
   jquery-rails
   pg

--- a/features/pharmacy_low_stock_alerts.feature
+++ b/features/pharmacy_low_stock_alerts.feature
@@ -31,26 +31,21 @@ Scenario: don't display alerts for drugs that are not low
 
 Scenario: update low stock alert status when drug stock changes
   When the quantity of "drug1" is set to 800
-  Then the low stock alert for "drug1" should be False
+  Then the low stock alert for "drug1" should be off
   When the quantity of "drug2" is set to 200
-  Then the low stock alert for "drug2" should be True
+  Then the low stock alert for "drug2" should be on
   When the quantity of "drug3" is set to 1001
-  Then the low stock alert for "drug3" should be False
-
-Scenario: set low stock alert to True if quantity is less than or equal to low stock point
-  When the quantity of "drug2" is set to 300
-  Then the low stock alert for "drug2" should be True
-  And the low stock alert for "drug3" should be True
+  Then the low stock alert for "drug3" should be off
 
 Scenario: update low stock alert status when drug low stock point chagnes
   When the low stock point of "drug1" is set to 800
-  Then the low stock alert for "drug1" should be False
+  Then the low stock alert for "drug1" should be off
   When the low stock point of "drug2" is set to 4000
-  Then the low stock alert for "drug2" should be True
+  Then the low stock alert for "drug2" should be on
   When the low stock point of "drug3" is set to 50
-  Then the low stock alert for "drug3" should be False
+  Then the low stock alert for "drug3" should be off
 
 Scenario: set low stock alert to True if quantity is less than or equal to low stock point
   When the quantity of "drug2" is set to 300
-  Then the low stock alert for "drug2" should be True
-  And the low stock alert for "drug3" should be True
+  Then the low stock alert for "drug2" should be on
+  And the low stock alert for "drug3" should be on

--- a/features/pharmacy_low_stock_alerts.feature
+++ b/features/pharmacy_low_stock_alerts.feature
@@ -12,15 +12,15 @@ Background: drugs in database
   | drug2   |     3205 | pack       |                    30 |                   |             300 | False           |
   | drug3   |      255 | pill       |                   100 |                   |            1000 | True            |
 
-Scenario: manually set the low_stock_point for an existing drug
-  When I manually set the low_stock_point for "drug2" to 200
-  Then the low_stock_point for "drug2" should be 200
+Scenario: manually set the low stock point for an existing drug
+  When I manually set the low stock point for "drug2" to 200
+  Then the low stock point for "drug2" should be 200
 
-Scenario: automatically set the low_stock_point for an existing drug
-  When I automatically set the low_stock_point for "drug2" to 200
-  Then the low_stock_point for "drug2" should be 200
+Scenario: automatically set the low stock point for an existing drug
+  When I automatically set the low stock point for "drug2" to 200
+  Then the low stock point for "drug2" should be 200
 
-Scenario: display alert when quantity of a drug is below its low_stock_point
+Scenario: display alert when quantity of a drug is below its low stock point
   When I am on the pharmacy dashboard
   Then I should see an alert for "drug3"
 
@@ -29,28 +29,28 @@ Scenario: don't display alerts for drugs that are not low
   Then I should not see an alert for "drug1"
   And I should not see an alert for "drug2"
 
-Scenario: update low_stock_alert status when drug stock changes
+Scenario: update low stock alert status when drug stock changes
   When the quantity of "drug1" is set to 800
-  Then the low_stock_alert for "drug1" should be False
+  Then the low stock alert for "drug1" should be False
   When the quantity of "drug2" is set to 200
-  Then the low_stock_alert for "drug2" should be True
+  Then the low stock alert for "drug2" should be True
   When the quantity of "drug3" is set to 1001
-  Then the low_stock_alert for "drug3" should be False
+  Then the low stock alert for "drug3" should be False
 
-Scenario: set low_stock_alert to True if quantity is less than or equal to low_stock_point
+Scenario: set low stock alert to True if quantity is less than or equal to low stock point
   When the quantity of "drug2" is set to 300
-  Then the low_stock_alert for "drug2" should be True
-  And the low_stock_alert for "drug3" should be True
+  Then the low stock alert for "drug2" should be True
+  And the low stock alert for "drug3" should be True
 
-Scenario: update low_stock_alert status when drug low_stock_point chagnes
-  When the low_stock_point of "drug1" is set to 800
-  Then the low_stock_alert for "drug1" should be False
-  When the low_stock_point of "drug2" is set to 4000
-  Then the low_stock_alert for "drug2" should be True
-  When the low_stock_point of "drug3" is set to 50
-  Then the low_stock_alert for "drug3" should be False
+Scenario: update low stock alert status when drug low stock point chagnes
+  When the low stock point of "drug1" is set to 800
+  Then the low stock alert for "drug1" should be False
+  When the low stock point of "drug2" is set to 4000
+  Then the low stock alert for "drug2" should be True
+  When the low stock point of "drug3" is set to 50
+  Then the low stock alert for "drug3" should be False
 
-Scenario: set low_stock_alert to True if quantity is less than or equal to low_stock_point
+Scenario: set low stock alert to True if quantity is less than or equal to low stock point
   When the quantity of "drug2" is set to 300
-  Then the low_stock_alert for "drug2" should be True
-  And the low_stock_alert for "drug3" should be True
+  Then the low stock alert for "drug2" should be True
+  And the low stock alert for "drug3" should be True

--- a/features/pharmacy_low_stock_alerts.feature
+++ b/features/pharmacy_low_stock_alerts.feature
@@ -14,11 +14,11 @@ Background: drugs in database
 
 Scenario: manually set the low_stock_point for an existing drug
   When I manually set the low_stock_point for "drug2" to 200
-  Then the low_stock_pint for "drug2" should be 200
+  Then the low_stock_point for "drug2" should be 200
 
 Scenario: automatically set the low_stock_point for an existing drug
   When I automatically set the low_stock_point for "drug2" to 200
-  Then the low_stock_pint for "drug2" should be 200
+  Then the low_stock_point for "drug2" should be 200
 
 Scenario: display alert when quantity of a drug is below its low_stock_point
   When I am on the pharmacy dashboard

--- a/features/pharmacy_low_stock_alerts.feature
+++ b/features/pharmacy_low_stock_alerts.feature
@@ -1,0 +1,56 @@
+Feature: display alert when stock is low (in pharmacy)
+
+  As a pharmacist
+  I want to set alerts that warn me when drug stock falls below a certain quantity
+  So that I know to order more
+
+Background: drugs in database
+
+  Given the following drugs exist:
+  | name    | quantity | units      | calculated_usage_rate | static_usage_rate | low_stock_point | low_stock_alert |
+  | drug1   |     1000 | milligram  |                    50 |                   |             500 | False           |
+  | drug2   |     3205 | pack       |                    30 |                   |             300 | False           |
+  | drug3   |      255 | pill       |                   100 |                   |            1000 | True            |
+
+Scenario: manually set the low_stock_point for an existing drug
+  When I manually set the low_stock_point for "drug2" to 200
+  Then the low_stock_pint for "drug2" should be 200
+
+Scenario: automatically set the low_stock_point for an existing drug
+  When I automatically set the low_stock_point for "drug2" to 200
+  Then the low_stock_pint for "drug2" should be 200
+
+Scenario: display alert when quantity of a drug is below its low_stock_point
+  When I am on the pharmacy dashboard
+  Then I should see an alert for "drug3"
+
+Scenario: don't display alerts for drugs that are not low
+  When I am on the pharmacy dashboard
+  Then I should not see an alert for "drug1"
+  And I should not see an alert for "drug2"
+
+Scenario: update low_stock_alert status when drug stock changes
+  When the quantity of "drug1" is set to 800
+  Then the low_stock_alert for "drug1" should be False
+  When the quantity of "drug2" is set to 200
+  Then the low_stock_alert for "drug2" should be True
+  When the quantity of "drug3" is set to 1001
+  Then the low_stock_alert for "drug3" should be False
+
+Scenario: set low_stock_alert to True if quantity is less than or equal to low_stock_point
+  When the quantity of "drug2" is set to 300
+  Then the low_stock_alert for "drug2" should be True
+  And the low_stock_alert for "drug3" should be True
+
+Scenario: update low_stock_alert status when drug low_stock_point chagnes
+  When the low_stock_point of "drug1" is set to 800
+  Then the low_stock_alert for "drug1" should be False
+  When the low_stock_point of "drug2" is set to 4000
+  Then the low_stock_alert for "drug2" should be True
+  When the low_stock_point of "drug3" is set to 50
+  Then the low_stock_alert for "drug3" should be False
+
+Scenario: set low_stock_alert to True if quantity is less than or equal to low_stock_point
+  When the quantity of "drug2" is set to 300
+  Then the low_stock_alert for "drug2" should be True
+  And the low_stock_alert for "drug3" should be True

--- a/features/step_definitions/drug_steps.rb
+++ b/features/step_definitions/drug_steps.rb
@@ -1,0 +1,44 @@
+Given /^the following drugs exist:$/ do |table|
+  # table is a Cucumber::Ast::Table
+  pending # express the regexp above with the code you wish you had
+end
+
+When /^I manually set the low_stock_point for "(.*?)" to (\d+)$/ do |arg1, arg2|
+  pending # express the regexp above with the code you wish you had
+end
+
+Then /^the low_stock_pint for "(.*?)" should be (\d+)$/ do |arg1, arg2|
+  pending # express the regexp above with the code you wish you had
+end
+
+When /^I automatically set the low_stock_point for "(.*?)" to (\d+)$/ do |arg1, arg2|
+  pending # express the regexp above with the code you wish you had
+end
+
+When /^I am on the pharmacy dashboard$/ do
+  pending # express the regexp above with the code you wish you had
+end
+
+Then /^I should see an alert for "(.*?)"$/ do |arg1|
+  pending # express the regexp above with the code you wish you had
+end
+
+Then /^I should not see an alert for "(.*?)"$/ do |arg1|
+  pending # express the regexp above with the code you wish you had
+end
+
+When /^the quantity of "(.*?)" is set to (\d+)$/ do |arg1, arg2|
+  pending # express the regexp above with the code you wish you had
+end
+
+Then /^the low_stock_alert for "(.*?)" should be False$/ do |arg1|
+  pending # express the regexp above with the code you wish you had
+end
+
+Then /^the low_stock_alert for "(.*?)" should be True$/ do |arg1|
+  pending # express the regexp above with the code you wish you had
+end
+
+When /^the low_stock_point of "(.*?)" is set to (\d+)$/ do |arg1, arg2|
+  pending # express the regexp above with the code you wish you had
+end

--- a/features/step_definitions/drug_steps.rb
+++ b/features/step_definitions/drug_steps.rb
@@ -1,44 +1,63 @@
 Given /^the following drugs exist:$/ do |table|
   # table is a Cucumber::Ast::Table
-  pending # express the regexp above with the code you wish you had
+  table.hashes.each do |drug|
+    # each returned element will be a hash whose key is the table header.
+    # add that movie to the database here.
+    Drug.create(drug)
+  end
 end
 
-When /^I manually set the low_stock_point for "(.*?)" to (\d+)$/ do |arg1, arg2|
-  pending # express the regexp above with the code you wish you had
+When /^I manually set the low_stock_point for "(.*?)" to (\d+)$/ do |name, amt|
+  drug = Drug.find_by_name(name)
+  visit('/#{drug.id}/edit')
+  fill_in('Low Stock Point', :with => amt)
+  click_button('submit')
 end
 
-Then /^the low_stock_pint for "(.*?)" should be (\d+)$/ do |arg1, arg2|
-  pending # express the regexp above with the code you wish you had
+Then /^the low_stock_point for "(.*?)" should be (\d+)$/ do |name, amt|
+  drug = Drug.find_by_name(name)
+  assert_equal(amt, drug.low_stock_point)
 end
 
-When /^I automatically set the low_stock_point for "(.*?)" to (\d+)$/ do |arg1, arg2|
-  pending # express the regexp above with the code you wish you had
+When /^I automatically set the low_stock_point for "(.*?)" to (\d+)$/ do |name, amt|
+  drug = Drug.find_by_name(name)
+  drug.low_stock_point = amt
 end
 
 When /^I am on the pharmacy dashboard$/ do
-  pending # express the regexp above with the code you wish you had
+  visit('/pharmacy')
 end
 
-Then /^I should see an alert for "(.*?)"$/ do |arg1|
-  pending # express the regexp above with the code you wish you had
+module AlertText
+  def alert(drugName)
+    return 'Low stock for #{drugName}'
+  end
 end
 
-Then /^I should not see an alert for "(.*?)"$/ do |arg1|
-  pending # express the regexp above with the code you wish you had
+Then /^I should see an alert for "(.*?)"$/ do |name|
+  assert_match(/#{alert(name)}/m, page.body)
 end
 
-When /^the quantity of "(.*?)" is set to (\d+)$/ do |arg1, arg2|
-  pending # express the regexp above with the code you wish you had
+Then /^I should not see an alert for "(.*?)"$/ do |name|
+  assert page.has_no_content(alert(name))
 end
 
-Then /^the low_stock_alert for "(.*?)" should be False$/ do |arg1|
-  pending # express the regexp above with the code you wish you had
+When /^the quantity of "(.*?)" is set to (\d+)$/ do |name, amt|
+  drug = Drug.find_by_name(name)
+  drug.quantity = amt
+end
+
+Then /^the low_stock_alert for "(.*?)" should be False$/ do |name|
+  drug = Drug.find_by_name(name)
+  assert_equal(False, drug.low_stock_alert)
 end
 
 Then /^the low_stock_alert for "(.*?)" should be True$/ do |arg1|
-  pending # express the regexp above with the code you wish you had
+  drug = Drug.find_by_name(name)
+  assert_equal(True, drug.low_stock_alert)
 end
 
-When /^the low_stock_point of "(.*?)" is set to (\d+)$/ do |arg1, arg2|
-  pending # express the regexp above with the code you wish you had
+When /^the low_stock_point of "(.*?)" is set to (\d+)$/ do |name, amt|
+  drug = Drug.find_by_name(name)
+  drug.low_stock_point = amt
 end

--- a/features/step_definitions/drug_steps.rb
+++ b/features/step_definitions/drug_steps.rb
@@ -47,12 +47,12 @@ When /^the quantity of "(.*?)" is set to (\d+)$/ do |name, amt|
   drug.quantity = amt
 end
 
-Then /^the low stock alert for "(.*?)" should be False$/ do |name|
+Then /^the low stock alert for "(.*?)" should be off$/ do |name|
   drug = Drug.find_by_name(name)
   assert_equal(False, drug.low_stock_alert)
 end
 
-Then /^the low stock alert for "(.*?)" should be True$/ do |arg1|
+Then /^the low stock alert for "(.*?)" should be on$/ do |arg1|
   drug = Drug.find_by_name(name)
   assert_equal(True, drug.low_stock_alert)
 end

--- a/features/step_definitions/drug_steps.rb
+++ b/features/step_definitions/drug_steps.rb
@@ -7,19 +7,19 @@ Given /^the following drugs exist:$/ do |table|
   end
 end
 
-When /^I manually set the low_stock_point for "(.*?)" to (\d+)$/ do |name, amt|
+When /^I manually set the low stock point for "(.*?)" to (\d+)$/ do |name, amt|
   drug = Drug.find_by_name(name)
   visit('/#{drug.id}/edit')
   fill_in('Low Stock Point', :with => amt)
   click_button('submit')
 end
 
-Then /^the low_stock_point for "(.*?)" should be (\d+)$/ do |name, amt|
+Then /^the low stock point for "(.*?)" should be (\d+)$/ do |name, amt|
   drug = Drug.find_by_name(name)
   assert_equal(amt, drug.low_stock_point)
 end
 
-When /^I automatically set the low_stock_point for "(.*?)" to (\d+)$/ do |name, amt|
+When /^I automatically set the low stock point for "(.*?)" to (\d+)$/ do |name, amt|
   drug = Drug.find_by_name(name)
   drug.low_stock_point = amt
 end
@@ -47,17 +47,17 @@ When /^the quantity of "(.*?)" is set to (\d+)$/ do |name, amt|
   drug.quantity = amt
 end
 
-Then /^the low_stock_alert for "(.*?)" should be False$/ do |name|
+Then /^the low stock alert for "(.*?)" should be False$/ do |name|
   drug = Drug.find_by_name(name)
   assert_equal(False, drug.low_stock_alert)
 end
 
-Then /^the low_stock_alert for "(.*?)" should be True$/ do |arg1|
+Then /^the low stock alert for "(.*?)" should be True$/ do |arg1|
   drug = Drug.find_by_name(name)
   assert_equal(True, drug.low_stock_alert)
 end
 
-When /^the low_stock_point of "(.*?)" is set to (\d+)$/ do |name, amt|
+When /^the low stock point of "(.*?)" is set to (\d+)$/ do |name, amt|
   drug = Drug.find_by_name(name)
   drug.low_stock_point = amt
 end


### PR DESCRIPTION
added cucumber tests and step definitions.

new files:
features/pharmacy_low_stock_alerts.feature
features/step_definitions/drug_steps.rb

tests currently fail because there is no Drug model.

Assumed Drug model has fields:
id
name
quantity
units
calculated_usage_rate
static_usage_rate
low_stock_point
low_stock_alert
