### PR TITLE
Pharmacy seeds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,3 +56,5 @@ gem 'haml'
 gem 'haml-rails'
 
 gem 'factory_girl_rails'
+
+gem 'chronic'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,7 @@ GEM
       xpath (~> 0.1.4)
     childprocess (0.3.5)
       ffi (~> 1.0, >= 1.0.6)
+    chronic (0.6.7)
     cucumber (1.2.1)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
@@ -162,6 +163,7 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
+  chronic
   cucumber-rails
   database_cleaner
   factory_girl_rails

--- a/db/seed/pharmacy/data/drug1.yaml
+++ b/db/seed/pharmacy/data/drug1.yaml
@@ -3,7 +3,6 @@
 ---
 name: Drug1
 quantity: 2000
-#units: mg
 ---
 - amount: -10
   timestamp: 1 day ago

--- a/db/seed/pharmacy/data/drug1.yaml
+++ b/db/seed/pharmacy/data/drug1.yaml
@@ -1,0 +1,21 @@
+# Drug 1: used steadily each day of the week, and is not in danger of running
+#         out.
+---
+name: Drug1
+quantity: 2000
+#units: mg
+---
+- amount: -10
+  timestamp: 1 day ago
+- amount: -10
+  timestamp: 2 days ago
+- amount: -10
+  timestamp: 3 days ago
+- amount: -10
+  timestamp: 4 days ago
+- amount: -10
+  timestamp: 5 days ago
+- amount: -10
+  timestamp: 6 days ago
+- amount: -10
+  timestamp: 7 days ago

--- a/db/seed/pharmacy/seeds.rb
+++ b/db/seed/pharmacy/seeds.rb
@@ -1,0 +1,14 @@
+require 'find'
+
+data_path = Rails.root.join('db', 'seed', 'pharmacy', 'data')
+
+Dir.glob(data_path.join('*.yaml')) do |path|
+  drug_data, delta_data = YAML.load_stream(File.open(path)).documents
+  drug = Drug.create(drug_data)
+  delta_data.each do |dd|
+    dd['timestamp'] = Chronic::parse(dd['timestamp'])
+    delta = DrugDelta.create(dd)
+    drug.drug_deltas << delta
+  end
+  drug.save
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,7 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+
+seed_files = Rails.root.join('db', 'seed', '*', 'seeds.rb')
+
+Dir.glob(seed_files){|path| load path}


### PR DESCRIPTION
Forgot to mention, but this resolves #8.

This set of commits creates a framework for loading seed data and uses that framework to create a _very small_ Pharmacy seed. The system should be straightforward enough that people can add their own seed data to facilitate development.

See commit messages for more details.
