### PR TITLE
Semanticize welcome page

### DIFF
--- a/app/assets/stylesheets/welcome.css
+++ b/app/assets/stylesheets/welcome.css
@@ -4,8 +4,15 @@
 */
 
 .modules {
+  display: block;
   margin: auto;
+  padding: 0;
   border: 0;
+  width: 320px;
+}
+
+.modules li {
+  display: inline-block;
 }
 
 .modules img {

--- a/app/assets/stylesheets/welcome.css
+++ b/app/assets/stylesheets/welcome.css
@@ -4,7 +4,6 @@
 */
 
 .modules {
-  display: block;
   margin: auto;
   padding: 0;
   border: 0;

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -1,17 +1,15 @@
 %h1 Modules
 
-%table.modules
-  %tr
-    %td
-      = link_to pharmacy_path do
-        = image_tag 'pharmacy.png', :alt => 'Pharmacy', :width => 144, :height => 144
-    %td
-      = link_to screener_path do
-        = image_tag 'screener.png', :alt => 'Screener', :width => 144, :height => 144
-  %tr
-    %td
-      = link_to registration_path do
-        = image_tag 'registration.png', :alt => 'Registration', :width => 144, :height => 144
-    %td
-      = link_to superuser_path do
-        = image_tag 'superuser.png', :alt => 'Superuser', :width => 144, :height => 144
+%ul.modules
+  %li
+    = link_to pharmacy_path do
+      = image_tag 'pharmacy.png', :alt => 'Pharmacy', :width => 144, :height => 144
+  %li
+    = link_to screener_path do
+      = image_tag 'screener.png', :alt => 'Screener', :width => 144, :height => 144
+  %li
+    = link_to registration_path do
+      = image_tag 'registration.png', :alt => 'Registration', :width => 144, :height => 144
+  %li
+    = link_to superuser_path do
+      = image_tag 'superuser.png', :alt => 'Superuser', :width => 144, :height => 144


### PR DESCRIPTION
The `table` on the welcome page offended my HTML sensibilities :(

I swapped it out for a `ul` instead, since that's really what we're presenting the user with: an unordered list of modules.

(I only noticed this because I ruined the welcome page while I was styling tables for the pharmacy view... whoops!)
