### PR TITLE
Added Psych to Gemfile, updated Pharmacy seeds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,3 +58,5 @@ gem 'haml-rails'
 gem 'factory_girl_rails'
 
 gem 'chronic'
+
+gem 'psych'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     nokogiri (1.5.5)
     pg (0.14.1)
     polyglot (0.3.3)
+    psych (1.3.4)
     rack (1.4.1)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -171,6 +172,7 @@ DEPENDENCIES
   haml-rails
   jquery-rails
   pg
+  psych
   rails (= 3.2.8)
   rspec-rails
   simplecov

--- a/db/seed/pharmacy/seeds.rb
+++ b/db/seed/pharmacy/seeds.rb
@@ -3,7 +3,7 @@ require 'find'
 data_path = Rails.root.join('db', 'seed', 'pharmacy', 'data')
 
 Dir.glob(data_path.join('*.yaml')) do |path|
-  drug_data, delta_data = YAML.load_stream(File.open(path)).documents
+  drug_data, delta_data = YAML.load_stream(File.open(path))
   drug = Drug.create(drug_data)
   delta_data.each do |dd|
     dd['timestamp'] = Chronic::parse(dd['timestamp'])


### PR DESCRIPTION
Resolves #20.

The short story is that Dan was using one YAML parser (Psych) and I was using another (Syck), which caused interface issues. I included Psych in the Gemfile to force us all to Psych, and updated the seeds file accordingly.

See commit messages for more info (especially if `bundle install` fails for you).
