### PR TITLE
Fixing input names to match fields on model

### DIFF
--- a/app/controllers/drugs_controller.rb
+++ b/app/controllers/drugs_controller.rb
@@ -7,7 +7,7 @@ class DrugsController < ApplicationController
     drug.alert_level = params[:alert_level]
     drug.save!
 
-    render :nothing => true
+    redirect_to pharmacy_path
   end
 end
 

--- a/app/views/pharmacy/index.html.haml
+++ b/app/views/pharmacy/index.html.haml
@@ -24,11 +24,11 @@
                 :class => :drug_form,
                 :data => {:id => drug.id},
                 :method => :put do
-                %label{:for => 'override'} Override:
-                = text_field_tag 'override', drug.user_rate,
+                %label{:for => 'user_rate'} Override:
+                = text_field_tag 'user_rate', drug.user_rate,
                   :class => 'override_field'
-                %label{:for => 'alert'} Alert if stock falls below:
-                = text_field :drug, :alert_level, :value => drug.alert_level,
+                %label{:for => 'alert_level'} Alert if stock falls below:
+                = text_field_tag 'alert_level', drug.alert_level,
                   :class => 'alert_field'
                 = submit_tag 'Update', :class => 'submit'
             %div.details_right


### PR DESCRIPTION
Added a non-js fallback for updating pharmacy drug items. This just redirects you to the pharmacy page.
