### PR TITLE
[pharmacy] Remove low stock point and use alert_level everywhere

### DIFF
--- a/app/models/drug.rb
+++ b/app/models/drug.rb
@@ -1,39 +1,12 @@
 class Drug < ActiveRecord::Base
   has_many :drug_deltas
-  attr_accessible :alert_level, :estimated_rate, :name, :user_rate, :units, :quantity, :low_stock_point
+  attr_accessible :alert_level, :estimated_rate, :name, :user_rate, :units, :quantity
 
   def alert?
     if self.alert_level and self.quantity
-      self.quantity < self.alert_level
+      self.quantity <= self.alert_level
     else
       false
-    end
-  end
-
-  def quantity=(q)
-    self[:quantity] = q
-    lsp = self[:low_stock_point]
-    if lsp == nil
-      return
-    end
-    if self[:quantity] <= lsp
-      self[:alert_level] = 1
-    elsif self[:quantity] > lsp
-      write_attribute(:alert_level, 0)
-    end
-
-  end
-
-  def low_stock_point=(lsp)
-    self[:low_stock_point] = lsp
-    q = self[:quantity]
-    if q == nil
-      return
-    end
-    if q <= self[:low_stock_point]
-      self[:alert_level] = 1
-    elsif q > self[:low_stock_point]
-      self[:alert_level] = 0
     end
   end
 

--- a/app/views/pharmacy/_drug_edit.html.haml
+++ b/app/views/pharmacy/_drug_edit.html.haml
@@ -23,7 +23,7 @@
               = f.label 'Alert if stock falls below:', :for => "alert_level_field-#{drug.id}"
               = f.text_field :alert_level, :id => "alert_level_field-#{drug.id}",
               :placeholder => "#{drug.units}"
-              = submit_tag 'Update', :class => 'submit'
+              = submit_tag 'Update', :class => 'submit', :id => "alert_level_submit-#{drug.id}"
         %div.details_right
           %div.estimated_rate
             Estimated rate:

--- a/db/migrate/20121023044702_remove_low_stock_point_from_drugs.rb
+++ b/db/migrate/20121023044702_remove_low_stock_point_from_drugs.rb
@@ -1,0 +1,9 @@
+class RemoveLowStockPointFromDrugs < ActiveRecord::Migration
+  def up
+    remove_column :drugs, :low_stock_point
+  end
+
+  def down
+    add_column :drugs, :low_stock_point, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121021220935) do
+ActiveRecord::Schema.define(:version => 20121023044702) do
 
   create_table "drug_delta", :force => true do |t|
     t.datetime "timestamp"
@@ -30,10 +30,9 @@ ActiveRecord::Schema.define(:version => 20121021220935) do
     t.float    "estimated_rate"
     t.float    "user_rate"
     t.float    "alert_level"
-    t.datetime "created_at",      :null => false
-    t.datetime "updated_at",      :null => false
+    t.datetime "created_at",     :null => false
+    t.datetime "updated_at",     :null => false
     t.string   "units"
-    t.integer  "low_stock_point"
   end
 
 end

--- a/features/pharmacy_drug_stock_length.feature
+++ b/features/pharmacy_drug_stock_length.feature
@@ -1,29 +1,30 @@
 Feature: Estimate how long drug stock will last
-	
-	As a pharmacist
-	I want to see estimates for how long current stock will last based on previous usage rates
-	so that I can tell when stocks will run out
+
+  As a pharmacist
+  I want to see estimates for how long current stock will last based on previous usage rates
+  so that I can tell when stocks will run out
 
 Background: drugs have been added to database, pharmacist is logged in
-	
-	Given the following drugs exist:
-  | id | name  | quantity | units     | user_rate | low_stock_point |
-  |  1 | drug1 |     1000 | milligram |           |             500 |
-  |  2 | drug2 |     3205 | pack      |           |             300 |
-  |  3 | drug3 |      10  | pill      |           |             100 |
-   
+
+  Given the following drugs exist:
+  | id | name  | quantity | units     | user_rate | alert_level |
+  |  1 | drug1 |     1000 | milligram |           |         500 |
+  |  2 | drug2 |     3205 | pack      |           |         300 |
+  |  3 | drug3 |       10 | pill      |           |         100 |
+
   And the following drug deltas exist:
   | drug_name | amount | description         | timestamp    |
   |   drug1   |   -500 | initial supply      | 2 days ago   |
   |   drug1   |   -500 | initial supply      | 1 day ago    |
   |   drug3   |   +200 | reinforcements      | 15 days ago  |
   |   drug3   |   -990 | patient consumption | 1 day ago    |
-  
-  And I am on the pharmacy dashboard
-Scenario: pharmacy page should show drug name and estimated time left based off of estimated rate of usage
-	Then I should see "drug1"
-  And "drug1" should have 7 days left
-	And "drug3" should have 2 hours left
 
-Scenario: drugs with missing information can't caluculate estimated time left
-	Then "drug2" should not have enough information to estimate the time left
+  And I am on the pharmacy dashboard
+
+  Scenario: pharmacy page should show drug name and estimated time left based off of estimated rate of usage
+    Then I should see "drug1"
+    And "drug1" should have 7 days left
+    And "drug3" should have 2 hours left
+
+  Scenario: drugs with missing information can't caluculate estimated time left
+    Then "drug2" should not have enough information to estimate the time left

--- a/features/pharmacy_low_stock_alerts.feature
+++ b/features/pharmacy_low_stock_alerts.feature
@@ -1,22 +1,22 @@
 Feature: display alert when stock is low (in pharmacy)
 
   As a pharmacist
-  I want to set alerts that warn me when drug stock falls below a certain quantity
+  I want to set and see alerts that warn me when drug stock falls below a certain quantity
   So that I know to order more
 
 Background: drugs in database
 
   Given the following drugs exist:
-  | name    | quantity | units      | estimated_rate | user_rate | low_stock_point | alert_level  |
-  | drug1   |     1000 | milligram  |             50 |        50 |             500 | 0            |
-  | drug2   |     3205 | pack       |             30 |        50 |             300 | 0            |
-  | drug3   |      255 | pill       |            100 |        50 |            1000 | 1            |
+  | name  | quantity | units     | alert_level |
+  | drug1 |     1000 | milligram |         500 |
+  | drug2 |     3205 | pack      |         300 |
+  | drug3 |      255 | pill      |        1000 |
 
-Scenario: manually set the low stock point for an existing drug
-  When I manually set the low stock point for "drug2" to 200
-  Then the low stock point for "drug2" should be 200
+Scenario: set the alert level for an existing drug
+  When I set the alert level of "drug2" to 200
+  Then the alert level for "drug2" should be 200
 
-Scenario: display alert when quantity of a drug is below its low stock point
+Scenario: display alert when quantity of a drug is below its alert level
   When I am on the pharmacy dashboard
   Then I should see an alert for "drug3"
 
@@ -25,31 +25,30 @@ Scenario: don't display alerts for drugs that are not low
   Then I should not see an alert for "drug1"
   And I should not see an alert for "drug2"
 
-Scenario: update low stock alert status when drug stock changes from above to above low stock point
+Scenario: update low stock alert status when drug stock changes from above to above alert level
   When the quantity of "drug1" is set to 800
-  Then the low stock alert for "drug1" should be off
+  Then I should not see an alert for "drug1"
 
-Scenario: update low stock alert status when drug stock changes from above to under low stock point
+Scenario: update low stock alert status when drug stock changes from above to under alert level
   When the quantity of "drug2" is set to 200
-  Then the low stock alert for "drug2" should be on
+  Then I should see an alert for "drug2"
 
-Scenario: update low stock alert status when drug stock changes from under to above low stock point
+Scenario: update low stock alert status when drug stock changes from under to above alert level
   When the quantity of "drug3" is set to 1001
-  Then the low stock alert for "drug3" should be off
+  Then I should not see an alert for "drug3"
 
-Scenario: update low stock alert status when drug low stock point changes from under to under stock quantity
-  When the low stock point of "drug1" is set to 800
-  Then the low stock alert for "drug1" should be off
+Scenario: update low stock alert status when drug alert level changes from under to under stock quantity
+  When I set the alert level of "drug1" to 800
+  Then I should not see an alert for "drug1"
 
-Scenario: update low stock alert status when drug low stock point changes from above to under stock quantity
-  When the low stock point of "drug2" is set to 4000
-  Then the low stock alert for "drug2" should be on
+Scenario: update low stock alert status when drug alert level changes from above to under stock quantity
+  When I set the alert level of "drug2" to 4000
+  Then I should not see an alert for "drug1"
 
-Scenario: update low stock alert status when drug low stock point changes from under to above stock quantity
-  When the low stock point of "drug3" is set to 50
-  Then the low stock alert for "drug3" should be off
+Scenario: update low stock alert status when drug alert level changes from under to above stock quantity
+  When I set the alert level of "drug3" to 50
+  Then I should not see an alert for "drug3"
 
-Scenario: set low stock alert to True if quantity is less than or equal to low stock point
+Scenario: see low stock alert if quantity is less than or equal to alert level
   When the quantity of "drug2" is set to 300
-  Then the low stock alert for "drug2" should be on
-  And the low stock alert for "drug3" should be on
+  Then I should see an alert for "drug2"

--- a/features/pharmacy_override_estimates.feature
+++ b/features/pharmacy_override_estimates.feature
@@ -6,9 +6,9 @@ Feature: Override estimates of drug usage rates
 
   Background: drugs have been added to database, pharmacist is logged in
     Given the following drugs exist:
-      | id | name   | quantity | units | user_rate | low_stock_point |
-      | 1  | drug A | 20       | pills |           | 20              |
-      | 2  | drug B | 20       | pills |           | 10              |
+      | id | name   | quantity | units | user_rate | alert_level |
+      |  1 | drug A |       20 | pills |           |          20 |
+      |  2 | drug B |       20 | pills |           |          10 |
     Given the following drug deltas exist:
       | drug_name | amount | description         | timestamp  |
       |    drug A |    -70 | something           | 2 days ago |

--- a/features/step_definitions/drug_steps.rb
+++ b/features/step_definitions/drug_steps.rb
@@ -31,45 +31,33 @@ end
 
 # Low stock checks
 
-When /^I manually set the low stock point for "(.*?)" to (\d+)$/ do |name, amt|
+When /^I set the alert level of "(.*?)" to (\d+)$/ do |name, amt|
   drug = Drug.find_by_name(name)
   visit('/pharmacy')
-  fill_in(:drug, :with => amt)
-  click_button('Update')
+  fill_in("alert_level_field-#{drug.id}", :with => amt)
+  click_button("alert_level_submit-#{drug.id}")
 end
 
-Then /^the low stock point for "(.*?)" should be (\d+)$/ do |name, amt|
+Then /^the alert level for "(.*?)" should be (\d+)$/ do |name, amt|
   drug = Drug.find_by_name(name)
-  assert_equal(amt, drug.low_stock_point)
+  drug.alert_level.should == amt.to_i
 end
 
 Then /^I should see an alert for "(.*?)"$/ do |name|
-  assert_match(/#{name}(.*)---/m, page.body)
+  visit('/pharmacy')
+  drug = Drug.find_by_name(name)
+  page.should have_selector "#drug#{drug.id} .alert"
 end
 
 Then /^I should not see an alert for "(.*?)"$/ do |name|
-  assert_match(/---(.*)#{name}/m, page.body)
+  visit('/pharmacy')
+  drug = Drug.find_by_name(name)
+  page.should have_no_selector "#drug#{drug.id} .alert"
 end
 
-When /^the quantity of "(.*?)" is set to (\d+)$/ do |name, amt|
+When /^the quantity of "(.*?)" is set to (\d+)$/ do |name, qty|
   drug = Drug.find_by_name(name)
-  drug.quantity = amt
-  drug.save
-end
-
-Then /^the low stock alert for "(.*?)" should be off$/ do |name|
-  drug = Drug.find_by_name(name)
-  assert_equal(0, drug.alert_level)
-end
-
-Then /^the low stock alert for "(.*?)" should be on$/ do |name|
-  drug = Drug.find_by_name(name)
-  assert_equal(1, drug.alert_level)
-end
-
-When /^the low stock point of "(.*?)" is set to (\d+)$/ do |name, amt|
-  drug = Drug.find_by_name(name)
-  drug.low_stock_point = amt
+  drug.quantity = qty
   drug.save
 end
 


### PR DESCRIPTION
Summary:
Having low_stock_point and alert_level is too confusing. I've picked alert_level
since both alert_level and quantitiy are floats, whereas low_stock_point is an
integer.

In making these modifications, the low_stock_alerts feature now passes.

Reviewers: @erictzeng, @danwang, @bucephalus, @stephaniege

Test Plan:

``` sh
$ cucumber features/pharmacy_low_stock_alerts.feature
```

Revert Plan:
Reverse the migration.
