### PR TITLE
Registration table "see more" link (aka 'patient j must die')

### DIFF
--- a/app/controllers/registrars_controller.rb
+++ b/app/controllers/registrars_controller.rb
@@ -15,7 +15,7 @@ class RegistrarsController < ApplicationController
   def index_or_show(regs)
     @num_today = regs.for_day(Time.now).count
     @average_time = average_time(regs)
-    @full = (params[:format] == 'full')
+    @full = (params[:full] == 'full')
     regs = regs.order("time_end DESC")
     regs = regs.limit(10) unless @full
     @registrations_and_divs = get_regs_by_date(regs)

--- a/app/controllers/registrars_controller.rb
+++ b/app/controllers/registrars_controller.rb
@@ -1,11 +1,13 @@
 class RegistrarsController < ApplicationController
   def index
+    @name = 'all registrars'
     index_or_show Registration.scoped
     render :show
   end
 
   def show
     registrar = Registrar.find(params[:id])
+    @name = registrar.name
     index_or_show registrar.registrations
   end
 

--- a/app/controllers/registrars_controller.rb
+++ b/app/controllers/registrars_controller.rb
@@ -17,6 +17,7 @@ class RegistrarsController < ApplicationController
     @average_time = average_time(regs)
     @full = (params[:full] == 'full')
     regs = regs.order("time_end DESC")
+    @num_regs_without_limit = regs.count
     regs = regs.limit(10) unless @full
     @registrations_and_divs = get_regs_by_date(regs)
   end

--- a/app/controllers/registrars_controller.rb
+++ b/app/controllers/registrars_controller.rb
@@ -1,23 +1,23 @@
 class RegistrarsController < ApplicationController
   def index
-    @num_today = Registration.for_day(Time.now).count
-    @average_time = average_time(Registration.all)
-
-    @registrations_and_divs = get_regs_by_date(Registration.all(:order => "time_end DESC"))
-
+    index_or_show Registration.scoped
     render :show
   end
 
   def show
     registrar = Registrar.find(params[:id])
-    @num_today = registrar.registrations_for_day(Time.now).count
-    @average_time = average_time(registrar.registrations)
-
-    @registrations_and_divs = get_regs_by_date(Registration.all(:order => "time_end DESC", :conditions => {:registrar_id => params[:id]}))
-
+    index_or_show registrar.registrations
   end
 
   protected
+  def index_or_show(regs)
+    @num_today = regs.for_day(Time.now).count
+    @average_time = average_time(regs)
+    @full = (params[:format] == 'full')
+    regs = regs.limit(10) unless @full
+    @registrations_and_divs = get_regs_by_date(regs)
+  end
+
   def average_time(registrations)
     total_time = registrations.map {|r| r.elapsed_time}.reduce(:+)
     if total_time

--- a/app/controllers/registrars_controller.rb
+++ b/app/controllers/registrars_controller.rb
@@ -14,6 +14,7 @@ class RegistrarsController < ApplicationController
     @num_today = regs.for_day(Time.now).count
     @average_time = average_time(regs)
     @full = (params[:format] == 'full')
+    regs = regs.order("time_end DESC")
     regs = regs.limit(10) unless @full
     @registrations_and_divs = get_regs_by_date(regs)
   end

--- a/app/views/registrars/_regist_table.html.haml
+++ b/app/views/registrars/_regist_table.html.haml
@@ -23,4 +23,4 @@
         %td.divider{:colspan => 3}
           %div
             %span
-              = link_to 'See more', self.url_for(:format => 'full')
+              = link_to 'See more', self.url_for(:full => 'full')

--- a/app/views/registrars/_regist_table.html.haml
+++ b/app/views/registrars/_regist_table.html.haml
@@ -18,7 +18,7 @@
           %td= registration.time_end.localtime.strftime('%l:%M %P')
           %td= registration.patient.name
           %td= registration.patient_status
-    - unless full
+    - unless full or num_regs_without_limit <= 10
       %tr
         %td.divider{:colspan => 3}
           %div

--- a/app/views/registrars/_regist_table.html.haml
+++ b/app/views/registrars/_regist_table.html.haml
@@ -18,9 +18,9 @@
           %td= registration.time_end.localtime.strftime('%l:%M %P')
           %td= registration.patient.name
           %td= registration.patient_status
-    %tr
-      %td.divider{:colspan => 3}
-        %div
-          -# please change the title attribute of the next line
-          %span
-            = link_to 'See more', nil
+    - unless full
+      %tr
+        %td.divider{:colspan => 3}
+          %div
+            %span
+              = link_to 'See more', self.url_for(:format => 'full')

--- a/app/views/registrars/show.html.haml
+++ b/app/views/registrars/show.html.haml
@@ -1,7 +1,7 @@
 = content_for :head do
   = stylesheet_link_tag :registrars
 
-%h2 Dashboard for Jacob Doe
+%h2= "Dashboard for #{@name}"
 %div.rightbar
   = render :partial => 'registrars/rightbar',
            :locals => {:num_today => @num_today, :average_time => @average_time}

--- a/app/views/registrars/show.html.haml
+++ b/app/views/registrars/show.html.haml
@@ -8,4 +8,5 @@
 
 = render :partial => 'registrars/regist_table',
          :locals => {:registrations_and_divs => @registrations_and_divs,
-                     :full => @full}
+                     :full => @full,
+                     :num_regs_without_limit => @num_regs_without_limit}

--- a/app/views/registrars/show.html.haml
+++ b/app/views/registrars/show.html.haml
@@ -7,4 +7,5 @@
            :locals => {:num_today => @num_today, :average_time => @average_time}
 
 = render :partial => 'registrars/regist_table',
-         :locals => {:registrations_and_divs => @registrations_and_divs}
+         :locals => {:registrations_and_divs => @registrations_and_divs,
+                     :full => @full}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,10 @@ RaxaVisualizations::Application.routes.draw do
   end
 
   scope 'registration', :as => :registration do
+    constraints :full => /full/ do
+      get 'registrars(/:full)' => 'registrars#index'
+      get 'registrars/:id(/:full)' => 'registrars#show'
+    end
     resources :registrars
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,8 @@ RaxaVisualizations::Application.routes.draw do
     end
   end
 
-  scope 'registration' do
-    resources :registrars, :as => :registration_registrars
+  scope 'registration', :as => :registration do
+    resources :registrars
   end
 
   # The priority is based upon order of creation:

--- a/features/registration/patients_table_overall.feature
+++ b/features/registration/patients_table_overall.feature
@@ -69,29 +69,18 @@ Scenario: show time reigstered (end time), patient name, and status for a regist
 Scenario: by default, show last 10 patients registered
     Then I should see the following patients: Patient A,Patient B,Patient C
     And I should see the following patients: Patient D,Patient E,Patient F
-    And I should see the following patients: Patient G,Patient H,Patient I,Patient J
-    But I should not see the following patients: Patient K,Patient L,Patient M
+    And I should see the following patients: Patient G,Patient H,Patient K,Patient L
+    But I should not see the following patients: Patient J,Patient I,Patient M
     But I should not see the following patients: Patient N,Patient O,Patient P
     But I should not see the following patients: Patient Q,Patient R,Patient S
     But I should not see the following patients: Patient T,Patient U,Patient V
 
-Scenario: see more, shows 10 more registrations
-    When I click the link "See more"
-    Then I should see the following patients: Patient A,Patient B,Patient C
-    And I should see the following patients: Patient D,Patient E,Patient F
-    And I should see the following patients: Patient G,Patient H,Patient I,Patient J
-    And I should see the following patients: Patient K,Patient L,Patient M
-    And I should see the following patients: Patient N,Patient O,Patient P
-    And I should see the following patients: Patient Q,Patient R,Patient S,Patient T
-    But I should not see the following patients: Patient U,Patient V
-
 Scenario: at end of registrations in history, show all
     When I click the link "See more"
-    And I click the link "See more"
     Then I should see the following patients: Patient A,Patient B,Patient C
     And I should see the following patients: Patient D,Patient E,Patient F
-    And I should see the following patients: Patient G,Patient H,Patient I,Patient J
-    And I should see the following patients: Patient K,Patient L,Patient M
+    And I should see the following patients: Patient G,Patient H,Patient K,Patient L
+    And I should see the following patients: Patient I,Patient J,Patient M
     And I should see the following patients: Patient N,Patient O,Patient P
     And I should see the following patients: Patient Q,Patient R,Patient S,Patient T
     And I should see the following patients: Patient U,Patient V
@@ -111,4 +100,4 @@ Scenario: show date header for yesterday
 
 Scenario: show date header by date
     Then I should see "Patient F" before the "2 days ago" header
-    And I should see the "2 days ago" header before "Patient J"
+    And I should see the "2 days ago" header before "Patient K"

--- a/features/step_definitions/registration_steps.rb
+++ b/features/step_definitions/registration_steps.rb
@@ -114,7 +114,8 @@ Then /^I should see "(.*?)" before the "(.*?)" header$/ do |arg1, arg2|
   else
     header = "YESTERDAY"
   end
-  assert_match(/#{arg1}(.*)#{header}/m, page.body)
+  (page.body =~ Regexp.new(arg1)).should < (page.body =~ Regexp.new(header, 'i'))
+  assert_match(/#{arg1}(.*)#{header}/im, page.body)
 end
 
 Then /^I should see the "(.*?)" header before "(.*?)"$/ do |arg1, arg2|
@@ -123,10 +124,10 @@ Then /^I should see the "(.*?)" header before "(.*?)"$/ do |arg1, arg2|
   else
     header = "YESTERDAY"
   end
-  assert_match(/#{header}(.*)#{arg2}/m, page.body)
+  (page.body =~ Regexp.new(header, 'i')).should < (page.body =~ Regexp.new(arg2))
+  #assert_match(/#{header}([.\s]*)#{arg2}/im, page.body)
 end
 
 Then /^I should list "(.*?)" before "(.*?)"$/ do |arg1, arg2|
-  assert_match(/#{arg1}(.*)#{arg2}/m, page.body)
+  (page.body =~ Regexp.new(arg1)).should < (page.body =~ Regexp.new(arg2))
 end
-

--- a/spec/controllers/registrars_controller_spec.rb
+++ b/spec/controllers/registrars_controller_spec.rb
@@ -2,19 +2,16 @@ require 'spec_helper'
 
 describe RegistrarsController do
   describe "GET index" do
-    it "should correctly assign the number of patients registered today" do
-      Registration.stub(:for_day => [double("Registration")])
+    it "should assign the number of patients registered today" do
       get :index
-      assigns(:num_today).should == 1
+      assigns(:num_today).should_not be_nil
     end
   end
   describe "GET show" do
-    it "should correctly assign the number of patients registered today" do
-      registrar = Registrar.create(:name => 'a')
-      registrations = [double("Registration"), double("Registration")]
-      Registrar.any_instance.stub(:registrations_for_day) { registrations }
+    it "should assign the number of patients registered today" do
+      registrar = Registrar.create(:name => 'Jon Ko')
       get :show, :id => registrar.id
-      assigns(:num_today).should == 2
+      assigns(:num_today).should_not be_nil
     end
   end
 end


### PR DESCRIPTION
The registration table "see more" link works now.

By default, views are limited to the last 10 entries. Clicking on "see more" reveals all of them by appending ".full" to the URL:

`/registration/registrars/1` becomes `/registration/registrars/1.full`

IT'S A CUCUMBER

FRIGGIN' PATIENT J
